### PR TITLE
use glOrtho instead gluOrtho2D for x64 compilation (link problem with…

### DIFF
--- a/example-calibration/src/ofApp.cpp
+++ b/example-calibration/src/ofApp.cpp
@@ -354,7 +354,7 @@ void ofApp::drawProjectorPattern(){
     ofViewport(projectorRect);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluOrtho2D(0,projectorRect.width, projectorRect.height, 0);
+    glOrtho(0, projectorRect.width, projectorRect.height, 0, -1, 1);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     {


### PR DESCRIPTION
use glOrtho instead gluOrtho2D for x64 compilation (link problem with glu32.lib) for calibration example.
